### PR TITLE
Support compatible command for processor count on darwin platform

### DIFF
--- a/src/rebar3_rust_utils.erl
+++ b/src/rebar3_rust_utils.erl
@@ -30,7 +30,10 @@ compile_crates(State) ->
 %% ===================================================================
 
 compile_crate(CrateDir, PrivDir) ->
-  Command = "cargo build --release -j$(nproc)",
+  Command = case os:type() of
+    {unix,darwin} ->  "cargo rustc --release -j$(sysctl -n hw.ncpu) -- -C link-args='-flat_namespace -undefined suppress'";
+    {unix,linux}  ->  "cargo build --release -j$(nproc)"
+  end,
 
   {ok, _} = rebar_utils:sh(Command, [{cd, CrateDir}, {use_stdout, true}]),
 


### PR DESCRIPTION
- nproc does not work on OSX
- also link errors on OSX, see https://github.com/hansihe/rustler/issues/12#issuecomment-254120027

#2 